### PR TITLE
new attribute muti_key{"key2", "key3"}

### DIFF
--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -22,7 +22,7 @@ struct nested {
     DERIVE_SERDE(nested,
             (&Self::version, "version", value_or_struct)
             (&Self::opt_desc ,"opt_desc")
-            (&Self::desc ,"desc", default_se{"default value"})
+            (&Self::desc ,"desc", default_{"default value"})
             .no_remain())
     std::string version;
     std::string desc;
@@ -32,10 +32,10 @@ struct nested {
 class test {
 public:
     DERIVE_SERDE(test,
-            (&Self::str, "str", default_se{"hello"})
+            (&Self::str, "str", default_{"hello"})
             (&Self::i,   "i")
             (&Self::vec, "vec")
-            (&Self::io,  "io", default_se{tenum::OUTPUT}, to_lower, under_to_dash)
+            (&Self::io,  "io", default_{tenum::OUTPUT}, to_lower, under_to_dash)
             (&Self::in,  "in", make_optional)
             (&Self::pri, "pri", to_upper, under_to_dash)
             (&Self::m ,  "m")
@@ -66,6 +66,7 @@ int main()
     })"_json;
 
     // try {
+
     test t = serde::serialize<test>(v);
     fmt::print("{}\n",serde::to_str(t.io));
 

--- a/examples/simple_example.cpp
+++ b/examples/simple_example.cpp
@@ -21,12 +21,11 @@ public:
         using namespace serde::attribute;
         serde::serde_struct(context, value)
             (&test::str, "str")
-            (&test::str, "str")
             (&test::i,   "i")
             (&test::vec, "vec")
             (&test::no_vec, "no_vec", make_optional)
             (&test::io,  "io")
-            (&test::pri, "pri")
+            (&test::pri, "pri", multi_key{"pri2"}, default_{"dd"})
             (&test::m ,  "m")
             ;
     }
@@ -46,7 +45,7 @@ int main()
 "i": 10,
 "vec": [ "one", "two", "three" ],
 "io": "INPUT",
-"pri" : "pri",
+"pri2" : "pri",
 "no_vec": ["t", "b"],
 "m" : { "a" : "1",
         "b" : "2",

--- a/include/serdepp/attribute/default.hpp
+++ b/include/serdepp/attribute/default.hpp
@@ -9,6 +9,7 @@ namespace serde::attribute {
     template<typename D>
     struct default_se {
         D&& default_value_;
+        [[deprecated("changed -> default_")]]
         explicit default_se(D&& default_value) noexcept : default_value_(std::move(default_value)) {}
         template<typename T, typename serde_ctx, typename Next, typename ...Attributes>
         constexpr inline void from(serde_ctx& ctx, T& data, std::string_view key,
@@ -30,7 +31,29 @@ namespace serde::attribute {
     // deduce guide
     template<typename D> default_se(D&&) -> default_se<D>;
 
-    template<typename T> using default_ = default_se<T>;
+    template<typename D>
+    struct default_ {
+        D&& default_value_;
+        explicit default_(D&& default_value) noexcept : default_value_(std::move(default_value)) {}
+        template<typename T, typename serde_ctx, typename Next, typename ...Attributes>
+        constexpr inline void from(serde_ctx& ctx, T& data, std::string_view key,
+                                   Next&& next_attr, Attributes&&... remains) {
+            using Helper = serde_adaptor_helper<typename serde_ctx::Adaptor>;
+            if(Helper::is_null(ctx.adaptor, key)) {
+                data = std::move(default_value_);
+            } else {
+                next_attr.from(ctx, data, key, remains...);
+            }
+        }
+
+        template<typename T, typename serde_ctx, typename Next, typename ...Attributes>
+        constexpr inline void into(serde_ctx& ctx, T& data, std::string_view key,
+                                   Next&& next_attr, Attributes&&... remains) {
+            next_attr.into(ctx, data, key, remains...);
+        }
+    };
+    // deduce guide
+    template<typename D> default_(D&&) -> default_<D>;
 }
 
 

--- a/include/serdepp/attribute/mutli_key.hpp
+++ b/include/serdepp/attribute/mutli_key.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#ifndef __SERDEPP_ATTRIBUTE_MULTI_KEY_HPP__
+#define __SERDEPP_ATTRIBUTE_MULTI_KEY_HPP__
+
+#include "serdepp/serializer.hpp"
+
+namespace serde::attribute {
+    struct multi_key {
+        std::vector<std::string_view> keys_;
+        explicit multi_key(std::initializer_list<std::string_view> keys) : keys_(keys) {}
+
+        template<typename serde_ctx>
+        inline std::string_view find_key(serde_ctx& ctx, std::string_view key) const{
+            using Helper = serde_adaptor_helper<typename serde_ctx::Adaptor>;
+            for(auto multi_key : keys_) { if(!Helper::is_null(ctx.adaptor, multi_key)) return multi_key; }
+            return key;
+        }
+
+        template<typename T, typename serde_ctx, typename Next, typename ...Attributes>
+        inline void from(serde_ctx& ctx, T& data, std::string_view key,
+                        Next&& next_attr, Attributes&&... remains) const {
+            next_attr.from(ctx, data, find_key(ctx, key), remains...);
+        }
+
+        template<typename T, typename serde_ctx, typename Next, typename ...Attributes>
+        inline void into(serde_ctx& ctx, T& data, std::string_view key,
+                        Next&& next_attr, Attributes&&... remains) const {
+            next_attr.into(ctx, data, key, remains...);
+        }
+    };
+}
+
+
+#endif

--- a/include/serdepp/attribute/string_convert.hpp
+++ b/include/serdepp/attribute/string_convert.hpp
@@ -19,7 +19,7 @@ namespace serde::attribute {
                 if constexpr(meta::is_enumable_v<ET>) {
                     enum_data_ = type::enum_t::from_str<ET>(data);
                 } else {
-                    throw serde::enum_error("this attribute requried enum type");
+                    throw serde::attribute_error("requried enum type");
                 }
             }
 
@@ -30,7 +30,7 @@ namespace serde::attribute {
                     data = type::enum_t::to_str(enum_data_);
                     next_attr.template into<std::string, serde_ctx>(ctx, data, key, remains...);
                 } else {
-                    throw serde::enum_error("this attribute requried enum type");
+                    throw serde::attribute_error("requried enum type");
                 }
             }
 
@@ -39,7 +39,7 @@ namespace serde::attribute {
                 if constexpr(meta::is_enumable_v<ET>) {
                     enum_data_ = type::enum_t::from_str<ET>(data);
                 } else {
-                    throw serde::enum_error("this attribute requried enum type");
+                    throw serde::attribute_error("this attribute requried enum type");
                 }
             }
 
@@ -48,7 +48,7 @@ namespace serde::attribute {
                 if constexpr(meta::is_enumable_v<ET>) {
                     data = type::enum_t::to_str(enum_data_);
                 } else {
-                    throw serde::enum_error("this attribute requried enum type");
+                    throw serde::attribute_error("this attribute requried enum type");
                 }
             }
             ET& enum_data_;
@@ -74,7 +74,7 @@ namespace serde::attribute {
                   }
                 }
                 else {
-                    throw serde::enum_error("this attribute requried str or enum type");
+                    throw serde::attribute_error("requried str or enum type");
                 }
             }
 
@@ -94,7 +94,7 @@ namespace serde::attribute {
                     transform{::tolower, ::toupper}.into(ctx, buffer, key, next_attr , remains...);
                 }
                 else {
-                    throw serde::enum_error("this attribute requried str or enum type");
+                    throw serde::attribute_error("requried str or enum type");
                 }
             }
         };
@@ -119,7 +119,7 @@ namespace serde::attribute {
                   }
                 }
                 else {
-                    throw serde::enum_error("this attribute requried str or enum type");
+                    throw serde::attribute_error("this attribute requried str or enum type");
                 }
             }
 
@@ -133,15 +133,15 @@ namespace serde::attribute {
                     std::string buffer;
                     auto se = str_enum(data);
                     se.template into<std::string, serde_ctx>(ctx, buffer, key,
-                                                                         transform{::toupper, ::tolower},
-                                                                         next_attr, remains...);
+                                                             transform{::toupper, ::tolower},
+                                                             next_attr, remains...);
                 }
                 else if constexpr(meta::is_str_v<T>) {
                     std::string buffer = data;
                     transform{::toupper, ::tolower}.into(ctx, data, key, next_attr, remains...);
                 }
                 else {
-                    throw serde::enum_error("this attribute requried str or enum type");
+                    throw serde::attribute_error("this attribute requried str or enum type");
                 }
             }
         };
@@ -184,15 +184,15 @@ namespace serde::attribute {
                     std::string buffer;
                     auto se = str_enum(data);
                     se.template into<std::string, serde_ctx>(ctx, buffer, key,
-                                                                         transform{to_under, to_dash},
-                                                                         next_attr, remains...);
+                                                             transform{to_under, to_dash},
+                                                             next_attr, remains...);
                 }
                 else if constexpr(meta::is_str_v<T>) {
                     std::string buffer = data;
                     transform{to_under, to_dash}.into(ctx, buffer, key, next_attr , remains...);
                 }
                 else {
-                    throw serde::enum_error("this attribute requried str or enum type");
+                    throw serde::attribute_error("this attribute requried str or enum type");
                 }
             }
         };

--- a/include/serdepp/attributes.hpp
+++ b/include/serdepp/attributes.hpp
@@ -10,6 +10,7 @@
 #include "serdepp/attribute/default.hpp"
 #include "serdepp/attribute/algorithm.hpp"
 #include "serdepp/attribute/make_optional.hpp"
+#include "serdepp/attribute/mutli_key.hpp"
 
 //namespace serde::attribute {}
 

--- a/include/serdepp/serializer.hpp
+++ b/include/serdepp/serializer.hpp
@@ -144,6 +144,7 @@ namespace serde
             return magic_enum::enum_name(value);
         }
         template <class Enum>
+
         inline constexpr static Enum from_str(std::string_view str) {
             auto value = magic_enum::enum_cast<Enum>(str);
             if (!value.has_value()) {
@@ -157,6 +158,7 @@ namespace serde
       template <typename T> using map_k = typename T::key_type;
       template <typename T> using seq_e = typename T::value_type;
       template <typename T> using opt_e = typename T::value_type;
+
 
       template <typename T, typename = void> struct not_null;
 
@@ -202,25 +204,8 @@ namespace serde
     using namespace std::string_view_literals;
 
     template <typename T, class Adaptor>
-    constexpr inline T serialize(Adaptor&& adaptor) {
+    constexpr inline T serialize(Adaptor&& adaptor, std::string_view key="") {
         using origin = meta::remove_cvref_t<Adaptor>;
-        T target;
-        serde_context<origin> ctx(adaptor);
-        serde_serializer<T, serde_context<origin>>::from(ctx, target, ""sv);
-        return target;
-    }
-
-    template<typename T, class Adaptor>
-    constexpr inline void serialize_to(Adaptor&& adaptor, T& target) {
-        using origin = meta::remove_cvref_t<Adaptor>;
-        serde_context<origin> ctx(adaptor);
-        serde_serializer<T, serde_context<origin>>::from(ctx, target, ""sv);
-    }
-
-    template<typename T, class Adaptor>
-    constexpr inline T serialize_at(Adaptor&& adaptor, std::string_view key) {
-        using origin = meta::remove_cvref_t<Adaptor>;
-
         T target;
         serde_context<origin> ctx(adaptor);
         serde_serializer<T, serde_context<origin>>::from(ctx, target, key);
@@ -228,31 +213,14 @@ namespace serde
     }
 
     template<typename T, class Adaptor>
-    constexpr inline void serialize_at_to(Adaptor& adaptor, T& target, std::string_view name) {
+    constexpr inline void serialize_to(Adaptor&& adaptor, T& target, std::string_view key="") {
         using origin = meta::remove_cvref_t<Adaptor>;
         serde_context<origin> ctx(adaptor);
-        serde_serializer<T, serde_context<origin>>::from(ctx, target, name);
-    }
-
-
-    template<class Adaptor, typename T>
-    constexpr inline Adaptor deserialize(T&& target) {
-        using origin = meta::remove_cvref_t<T>;
-        Adaptor adaptor;
-        serde_context<Adaptor, false> ctx(adaptor);
-        serde_serializer<origin, serde_context<Adaptor,false>>::into(ctx, target, ""sv);
-        return adaptor;
-    }
-
-    template<class Adaptor, typename T, typename U = meta::remove_cvref_t<T>>
-    constexpr inline void deserialize_from(T&& target, Adaptor& adaptor) {
-        using origin = meta::remove_cvref_t<T>;
-        serde_context<Adaptor, false> ctx(adaptor);
-        serde_serializer<origin, serde_context<Adaptor,false>>::into(ctx, target, ""sv);
+        serde_serializer<T, serde_context<origin>>::from(ctx, target, key);
     }
 
     template<class Adaptor, typename T>
-    constexpr inline Adaptor deserialize_by(T&& target, std::string_view key) {
+    constexpr inline Adaptor deserialize(T&& target, std::string_view key="") {
         using origin = meta::remove_cvref_t<T>;
         Adaptor adaptor;
         serde_context<Adaptor, false> ctx(adaptor);
@@ -261,7 +229,7 @@ namespace serde
     }
 
     template<class Adaptor, typename T, typename U = meta::remove_cvref_t<T>>
-    constexpr inline void deserialize_by_from(Adaptor& adaptor, T&& target, std::string_view key) {
+    constexpr inline void deserialize_from(T&& target, Adaptor& adaptor, std::string_view key="") {
         using origin = meta::remove_cvref_t<T>;
         serde_context<Adaptor, false> ctx(adaptor);
         serde_serializer<origin, serde_context<Adaptor,false>>::into(ctx, target, key);
@@ -271,7 +239,6 @@ namespace serde
     constexpr inline Adaptor parse_file(const std::string& path) {
         return serde_adaptor_helper<Adaptor>::parse_file(path);
     }
-
 
     template<class Context, class T>
     class serde_struct {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -7,8 +7,8 @@
 
 using namespace serde::attribute;
 struct tt {
-    derive_serde(tt,
-                 .field(&Self::a, "a", set_default{1})
+    DERIVE_SERDE(tt,
+                 .field(&Self::a, "a", default_{1})
                  .field(&Self::b, "b")
                  )
     int a;
@@ -69,7 +69,7 @@ int main(int argc, char* argv[]) {
     nlohmann::json json = R"({"a": 1, "b": 222})"_json;
 
     
-    int normal = serialize_at<int>(R"({"num":10})"_json, "num");
+    int normal = serialize<int>(R"({"num":10})"_json, "num");
     deserialize<nlohmann::json>(normal);
     fmt::print("{}\n",normal);
 


### PR DESCRIPTION
if you want use mutli_key with default
(&test::str, "key1", multi_key{"key2", "key3"}, default_{"hello world"})